### PR TITLE
Bump Rubocop TargetRubyVersion to 2.4

### DIFF
--- a/.rubocop-unstable.yml
+++ b/.rubocop-unstable.yml
@@ -7,7 +7,7 @@
 inherit_from:
   - https://raw.githubusercontent.com/hanami/devtools/master/.rubocop.yml
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - "vendor/**/*"
     - "vendor/**/.*" # See https://github.com/bbatsov/rubocop/issues/4832


### PR DESCRIPTION
Hello there!

I ended up in this repo when I was going after this [issue](https://github.com/hanami/hanami/issues/921), trying to update the [Hanami Model](https://github.com/hanami/model) ruby version to `2.4.0`. As I've just started diving into Hanami's source code it looked like a great starting point! :D

**I tried to fork the repo mentioned in the Readme but the response was 404** :( I hope this PR in this repo is OK. Let me know. 

As I mentioned I started the changes for the ruby version update for the Model repo. The tests were failing due to the `TargetRubyVersion`, as the issue addressed. I modified it in the `rubocop-stable.yml`, and checked if Model's tests passed.

[Here is the related PR for the Hanami Model repo.](https://github.com/hanami/model/pull/487)

---

Ref hanami/hanami#921