### PR TITLE
Rubocop Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: false
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3
 Bundler/OrderedGems:
   Enabled: false
 Gemspec/OrderedDependencies:

--- a/hanami-devtools.gemspec
+++ b/hanami-devtools.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_dependency "poltergeist", "~> 1.17"
   spec.add_dependency "rack", "~> 2.0"
   spec.add_dependency "rspec", "~> 3.7"
-  spec.add_dependency "rubocop", "~> 0.83.0"
   spec.add_dependency "hanami-utils"
 
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Remove `rubocop` as a development dependency from this gem.

Hanami gems are going to manage their own `rubocop` versions in `master` and `unstable` git branches.