### PR TITLE
Don't prohibit Hash[] syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,6 +99,8 @@ Style/FrozenStringLiteralComment:
   Enabled: true
 Style/GuardClause:
   Enabled: false
+Style/HashConversion:
+  Enabled: false
 Style/HashEachMethods:
   Enabled: false
 Style/HashTransformKeys:


### PR DESCRIPTION
This is in Rubocop v1.10 https://github.com/rubocop/rubocop/pull/9478

It seems like the intention is to prevent `Hash[ary]` and to encourage `ary.to_h` instead. But this also sweeps up every use of `Hash[]`. We have had that `Hash[]` call in specs we generated for Hanami 1.3 apps. I'd like to see that continue when we do Hanami 2.0 generators.

I personally much prefer `Hash[]` particularly when it's in a block. The squiqqly braces mean two different things in Ruby: a hash literal or a block. By avoiding using them as hash literal, it make its clear that they're used for blocks most often. (I'm not a purist about this, I just think it's easier to read often. With nested hashes, I often resort to hash literals inside a `Hash[]` call.)