### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,7 +103,7 @@ Style/ExpandPathArguments:
 Style/FormatString:
   Enabled: false
 Style/FrozenStringLiteralComment:
-  Enabled: true
+  Enabled: false
 Style/GuardClause:
   Enabled: false
 Style/HashConversion:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 require "bundler/gem_tasks"
 task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/devtools"
 

--- a/hanami-devtools.gemspec
+++ b/hanami-devtools.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "hanami/devtools/version"

--- a/lib/hanami/devtools.rb
+++ b/lib/hanami/devtools.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # Hanami devtools
   module Devtools

--- a/lib/hanami/devtools/integration.rb
+++ b/lib/hanami/devtools/integration.rb
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 require "hanami/utils"
 Hanami::Utils.require!("#{__dir__}/integration")

--- a/lib/hanami/devtools/integration/bundler.rb
+++ b/lib/hanami/devtools/integration/bundler.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "open3"
 require "pathname"
 require "hanami/devtools/integration/env"

--- a/lib/hanami/devtools/integration/capybara.rb
+++ b/lib/hanami/devtools/integration/capybara.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "capybara"
 require "capybara/rspec"
 require "capybara/dsl"

--- a/lib/hanami/devtools/integration/cli.rb
+++ b/lib/hanami/devtools/integration/cli.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "aruba"
 require "aruba/api"
 require "pathname"

--- a/lib/hanami/devtools/integration/coverage.rb
+++ b/lib/hanami/devtools/integration/coverage.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module RSpec
   module Support
     # Code coverage support

--- a/lib/hanami/devtools/integration/dns.rb
+++ b/lib/hanami/devtools/integration/dns.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "resolv-replace"
 
 module RSpec

--- a/lib/hanami/devtools/integration/env.rb
+++ b/lib/hanami/devtools/integration/env.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "singleton"
 module RSpec
   module Support

--- a/lib/hanami/devtools/integration/files.rb
+++ b/lib/hanami/devtools/integration/files.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/files"
 
 module RSpec

--- a/lib/hanami/devtools/integration/gemfile.rb
+++ b/lib/hanami/devtools/integration/gemfile.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "digest"
 require "hanami/utils/files"
 

--- a/lib/hanami/devtools/integration/hanami_commands.rb
+++ b/lib/hanami/devtools/integration/hanami_commands.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/integration/bundler"
 require "hanami/devtools/integration/files"
 require "hanami/devtools/integration/retry"

--- a/lib/hanami/devtools/integration/platform.rb
+++ b/lib/hanami/devtools/integration/platform.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Matchers for current OS, Ruby engine.
 #
 # @since 0.2.0

--- a/lib/hanami/devtools/integration/platform/engine.rb
+++ b/lib/hanami/devtools/integration/platform/engine.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils"
 
 module Platform

--- a/lib/hanami/devtools/integration/platform/matcher.rb
+++ b/lib/hanami/devtools/integration/platform/matcher.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/basic_object"
 
 module Platform

--- a/lib/hanami/devtools/integration/platform/os.rb
+++ b/lib/hanami/devtools/integration/platform/os.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rbconfig"
 
 module Platform

--- a/lib/hanami/devtools/integration/project_without_hanami_model.rb
+++ b/lib/hanami/devtools/integration/project_without_hanami_model.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/integration/with_clean_env_project"
 
 module RSpec

--- a/lib/hanami/devtools/integration/rack_test.rb
+++ b/lib/hanami/devtools/integration/rack_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack"
 require "rack/test"
 require "excon"

--- a/lib/hanami/devtools/integration/random_port.rb
+++ b/lib/hanami/devtools/integration/random_port.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "socket"
 require "timeout"
 

--- a/lib/hanami/devtools/integration/retry.rb
+++ b/lib/hanami/devtools/integration/retry.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module RSpec
   module Support
     # Implement retry logic.

--- a/lib/hanami/devtools/integration/silently.rb
+++ b/lib/hanami/devtools/integration/silently.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "tempfile"
 
 module RSpec

--- a/lib/hanami/devtools/integration/with_clean_env_project.rb
+++ b/lib/hanami/devtools/integration/with_clean_env_project.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/integration/with_project"
 require "hanami/devtools/integration/bundler"
 

--- a/lib/hanami/devtools/integration/with_directory.rb
+++ b/lib/hanami/devtools/integration/with_directory.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 
 module RSpec

--- a/lib/hanami/devtools/integration/with_project.rb
+++ b/lib/hanami/devtools/integration/with_project.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/integration/silently"
 require "hanami/devtools/integration/bundler"
 require "hanami/devtools/integration/with_tmp_directory"

--- a/lib/hanami/devtools/integration/with_system_tmp_directory.rb
+++ b/lib/hanami/devtools/integration/with_system_tmp_directory.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/integration/with_tmp_directory"
 
 module RSpec

--- a/lib/hanami/devtools/integration/with_tmp_directory.rb
+++ b/lib/hanami/devtools/integration/with_tmp_directory.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "fileutils"
 require "hanami/utils/files"
 require "hanami/devtools/integration/with_directory"

--- a/lib/hanami/devtools/integration/within_project_directory.rb
+++ b/lib/hanami/devtools/integration/within_project_directory.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 require "hanami/devtools/integration/with_directory"
 require "hanami/devtools/integration/env"

--- a/lib/hanami/devtools/rake_helper.rb
+++ b/lib/hanami/devtools/rake_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 
 module Hanami

--- a/lib/hanami/devtools/rake_tasks.rb
+++ b/lib/hanami/devtools/rake_tasks.rb
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/rake_helper"
 Hanami::Devtools::RakeHelper.install_tasks

--- a/lib/hanami/devtools/unit.rb
+++ b/lib/hanami/devtools/unit.rb
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 require "hanami/utils"
 Hanami::Utils.require!("#{__dir__}/unit")

--- a/lib/hanami/devtools/unit/support/coverage.rb
+++ b/lib/hanami/devtools/unit/support/coverage.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if ENV["CI"]
   require "simplecov"
 

--- a/lib/hanami/devtools/unit/support/silence_deprecations.rb
+++ b/lib/hanami/devtools/unit/support/silence_deprecations.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rspec"
 require "hanami/utils/io"
 

--- a/lib/hanami/devtools/version.rb
+++ b/lib/hanami/devtools/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Devtools
     VERSION = "2023.02.16"


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.