### PR TITLE
Add base64 and resolv-replace to dependencies

### DIFF
--- a/hanami-devtools.gemspec
+++ b/hanami-devtools.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_dependency "rspec", "~> 3.7"
   spec.add_dependency "dry-core", ">= 0.9", "< 2"
   spec.add_dependency "hanami-utils"
+  spec.add_dependency "base64"
+  spec.add_dependency "resolv-replace"
 
   spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
I don't know if we should add version constraints? I did for the other PR's adding dependencies for Ruby 3.4. They're both pre-1.0 so it might be wise, though I feel like if they break, we'd find it in hanami/hanami failures and that would lead us here