### PR TITLE
Change HashSyntax EnforcedShorthandSyntax to either_consistent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,7 +119,7 @@ Style/HashConversion:
 Style/HashEachMethods:
   Enabled: false
 Style/HashSyntax:
-  EnforcedShorthandSyntax: never
+  EnforcedShorthandSyntax: either_consistent
 Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:


### PR DESCRIPTION
https://rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax
```ruby

# good - `foo` and `bar` values can be omitted, but they are consistent, so it's accepted
{foo: foo, bar: bar}

# bad - `bar` value can be omitted
{foo:, bar: bar}

# bad - mixed syntaxes
{foo:, bar: baz}

# good
{foo:, bar:}

# good - can't omit `baz`
{foo: foo, bar: baz}
```

I'd like to move to `consistent` or `always` eventually but this is less noisy for pre-3.1 code.